### PR TITLE
Add filtering by pullrequest source and target branch #1

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/AbstractPullRequestFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/AbstractPullRequestFilter.java
@@ -50,7 +50,7 @@ public abstract class AbstractPullRequestFilter<T> extends SCMHeadFilter {
      *
      * @param filter {@link TypeFilter} to validate the data
      */
-    protected AbstractPullRequestFilter(TypeFilter filter) {
+    protected AbstractPullRequestFilter(TypeFilter<T> filter) {
         this.filter = filter;
     }
 
@@ -87,7 +87,7 @@ public abstract class AbstractPullRequestFilter<T> extends SCMHeadFilter {
      */
     protected boolean isAccepted(BitbucketPullRequest pullRequest) {
         T data = getData(pullRequest);
-        TypeFilter filter = getFilter();
+        TypeFilter<T> filter = getFilter();
         if (filter == null) {
             return true;
         }

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchMatchesFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchMatchesFilter.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
+
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.AbstractPullRequestFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+
+/**
+ * A {@link SCMHead} filter to only include pull request that originate from specific branches.
+ * 
+ * @since 0.2.0
+ *
+ */
+public class PullRequestSourceBranchMatchesFilter extends AbstractPullRequestFilter<String> {
+
+    /**
+     * {@inheritDoc}
+     */
+	public PullRequestSourceBranchMatchesFilter(StringFilter filter) {
+		super(filter);
+	}
+
+    /**
+     * {@inheritDoc}
+     */
+	@Override
+	protected String getData(BitbucketPullRequest pullRequest) {
+		return pullRequest.getSource().getBranch().getName();
+	}
+
+    /**
+     * {@inheritDoc}
+     */
+	@Override
+	protected String getMessage(BitbucketPullRequest pullRequest) {
+        return "The pull request originates from the ignorelisted branch: '"+ pullRequest.getSource().getBranch().getName() + "' Skipped.";
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchNotMatchesFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchNotMatchesFilter.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
+
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+
+/**
+ * A {@link SCMHead} filter to exclude pull request that originate from specific branches.
+ * 
+ * @since 0.2.0
+ *
+ */
+public class PullRequestSourceBranchNotMatchesFilter extends PullRequestSourceBranchMatchesFilter {
+
+    /**
+     * {@inheritDoc}
+     */
+	public PullRequestSourceBranchNotMatchesFilter(StringFilter filter) {
+		super(filter);
+	}
+	
+    /**
+     * {@inheritDoc}
+     */
+	@Override
+	protected boolean isAccepted(BitbucketPullRequest pullRequest) {
+        if (!this.getFilter().canFilter()) {
+            return true;
+        }
+
+        return !super.isAccepted(pullRequest);
+	}
+
+    /**
+     * {@inheritDoc}
+     */
+	@Override
+	protected String getMessage(BitbucketPullRequest pullRequest) {
+        return "The pull request originates from the ignorelisted branch: '"+ pullRequest.getSource().getBranch().getName() + "' Skipped.";
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchMatchesFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchMatchesFilter.java
@@ -29,17 +29,17 @@ import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringF
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 
 /**
- * A {@link SCMHead} filter to only include pull request that originate from specific branches.
+ * A {@link SCMHead} filter to only include pull request that target specific branches.
  * 
  * @since 0.2.0
  *
  */
-public class PullRequestSourceBranchMatchesFilter extends AbstractPullRequestFilter<String> {
+public class PullRequestTargetBranchMatchesFilter extends AbstractPullRequestFilter<String> {
 
     /**
      * {@inheritDoc}
      */
-	public PullRequestSourceBranchMatchesFilter(StringFilter filter) {
+	public PullRequestTargetBranchMatchesFilter(StringFilter filter) {
 		super(filter);
 	}
 
@@ -48,7 +48,7 @@ public class PullRequestSourceBranchMatchesFilter extends AbstractPullRequestFil
      */
 	@Override
 	protected String getData(BitbucketPullRequest pullRequest) {
-		return pullRequest.getSource().getBranch().getName();
+		return pullRequest.getDestination().getBranch().getName();
 	}
 
     /**
@@ -56,7 +56,7 @@ public class PullRequestSourceBranchMatchesFilter extends AbstractPullRequestFil
      */
 	@Override
 	protected String getMessage(BitbucketPullRequest pullRequest) {
-        return "The pull request does not originate from an allowlisted branch: '"+ pullRequest.getSource().getBranch().getName() + "' Skipped.";
+        return "The pull request does not target an allowlisted branch, instead: '"+ pullRequest.getDestination().getBranch().getName() + "' Skipped.";
 	}
 
 }

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchNotMatchesFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchNotMatchesFilter.java
@@ -23,32 +23,35 @@
  */
 package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
 
-import org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.AbstractPullRequestFilter;
 import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 
 /**
- * A {@link SCMHead} filter to only include pull request that originate from specific branches.
+ * A {@link SCMHead} filter to exclude pull request that originate from specific branches.
  * 
  * @since 0.2.0
  *
  */
-public class PullRequestSourceBranchMatchesFilter extends AbstractPullRequestFilter<String> {
+public class PullRequestTargetBranchNotMatchesFilter extends PullRequestTargetBranchMatchesFilter {
 
     /**
      * {@inheritDoc}
      */
-	public PullRequestSourceBranchMatchesFilter(StringFilter filter) {
+	public PullRequestTargetBranchNotMatchesFilter(StringFilter filter) {
 		super(filter);
 	}
-
+	
     /**
      * {@inheritDoc}
      */
 	@Override
-	protected String getData(BitbucketPullRequest pullRequest) {
-		return pullRequest.getSource().getBranch().getName();
+	protected boolean isAccepted(BitbucketPullRequest pullRequest) {
+        if (!this.getFilter().canFilter()) {
+            return true;
+        }
+
+        return !super.isAccepted(pullRequest);
 	}
 
     /**
@@ -56,7 +59,7 @@ public class PullRequestSourceBranchMatchesFilter extends AbstractPullRequestFil
      */
 	@Override
 	protected String getMessage(BitbucketPullRequest pullRequest) {
-        return "The pull request does not originate from an allowlisted branch: '"+ pullRequest.getSource().getBranch().getName() + "' Skipped.";
+        return "The pull request targets an ignorelisted branch: '"+ pullRequest.getDestination().getBranch().getName() + "' Skipped.";
 	}
 
 }

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait.java
@@ -1,0 +1,193 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.traits;
+
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch.PullRequestSourceBranchMatchesFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch.PullRequestSourceBranchNotMatchesFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.TypeFilter;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import hudson.Extension;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+
+/**
+ * A {@link Discovery} trait for Bitbucket source that will ignore pull requests
+ * matching any a specified branch filter.
+ *
+ * @since 0.2.0
+ */
+public class PullRequestSourceBranchFilterTrait extends SCMSourceTrait {
+
+	private int strategyId;
+
+	private String phrase;
+	private boolean ignoreCase;
+	private boolean regex;
+
+	/**
+	 * Constructor.
+	 */
+	@DataBoundConstructor
+	public PullRequestSourceBranchFilterTrait(int strategyId, String phrase, boolean ignoreCase, boolean regex) {
+		this.strategyId = strategyId;
+		this.phrase = phrase;
+		this.ignoreCase = ignoreCase;
+		this.regex = regex;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public int getStrategyId() {
+		return this.strategyId;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public String getPhrase() {
+		return this.phrase;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public boolean isIgnoreCase() {
+		return ignoreCase;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public boolean isRegex() {
+		return regex;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean includeCategory(@Nonnull SCMHeadCategory category) {
+		return category.isUncategorized();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected void decorateContext(SCMSourceContext<?, ?> context) {
+		StringFilter filter = createFilter();
+		if (strategyId == 1) {
+			context.withFilter(new PullRequestSourceBranchNotMatchesFilter(filter));
+		} else if (strategyId == 2) {
+			context.withFilter(new PullRequestSourceBranchMatchesFilter(filter));
+		}
+	}
+
+	/**
+	 * Create a filter to validate the data of pull request.
+	 *
+	 * @return A {@link TypeFilter} instance to validate the extracted data from
+	 *         pull request.
+	 */
+	protected StringFilter createFilter() {
+		try {
+			if (regex) {
+				int regexFlags = ignoreCase ? Pattern.CASE_INSENSITIVE : 0;
+				return new StringFilter(phrase != null ? Pattern.compile(phrase, regexFlags) : null);
+			}
+			return new StringFilter(phrase, ignoreCase);
+		} catch (Throwable t) {
+			return null;
+		}
+	}
+
+	@Extension
+	@Discovery
+	public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public String getDisplayName() {
+			return "Filter by pull requests origin branch";
+		}
+
+		/**
+		 * Populates the strategy options.
+		 *
+		 * @return the strategy options.
+		 */
+		@Nonnull
+		@Restricted(NoExternalUse.class)
+		@SuppressWarnings("unused") // stapler
+		public ListBoxModel doFillStrategyIdItems() {
+			ListBoxModel result = new ListBoxModel();
+			result.add("Accept pull requests from all sources", "0");
+			result.add("Ignore pull requests when source branch matches the phrase", "1");
+			result.add("Accept pull request only when the source branch matches the phrase", "2");
+			return result;
+		}
+
+		/**
+		 * Validate the inputs
+		 *
+		 * @param phrase      The phrase or the regular expression as pattern to
+		 *                    matching
+		 * @param ignoreCase  Ignore case sensitivity
+		 * @param regex       Treat the phrase as regular expression
+		 * @param testMatcher The subject to validate by the pattern or the phrase
+		 * @return validation status
+		 */
+		@Nonnull
+		@Restricted(NoExternalUse.class)
+		public FormValidation doTestPhrase(@QueryParameter("phrase") final String phrase,
+				@QueryParameter("ignoreCase") final boolean ignoreCase, @QueryParameter("regex") final boolean regex,
+				@QueryParameter("testMatcher") final String testMatcher) {
+			try {
+				StringFilter filter;
+				if (regex) {
+					filter = new StringFilter(Pattern.compile(phrase, ignoreCase ? Pattern.CASE_INSENSITIVE : 0));
+				} else {
+					filter = new StringFilter(phrase, ignoreCase);
+				}
+				if (filter.accepted(testMatcher)) {
+					return FormValidation.ok("The phrase is valid and matches!");
+				} else {
+					return FormValidation.warning("The phrase is valid but not matches!");
+				}
+			} catch (Throwable t) {
+				return FormValidation.error("Invalid phrase: " + t.getMessage());
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait.java
@@ -1,0 +1,193 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.traits;
+
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch.PullRequestTargetBranchMatchesFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch.PullRequestTargetBranchNotMatchesFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.TypeFilter;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import hudson.Extension;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+
+/**
+ * A {@link Discovery} trait for Bitbucket source that will ignore pull requests
+ * matching any a specified branch filter.
+ *
+ * @since 0.2.0
+ */
+public class PullRequestTargetBranchFilterTrait extends SCMSourceTrait {
+
+	private int strategyId;
+
+	private String phrase;
+	private boolean ignoreCase;
+	private boolean regex;
+
+	/**
+	 * Constructor.
+	 */
+	@DataBoundConstructor
+	public PullRequestTargetBranchFilterTrait(int strategyId, String phrase, boolean ignoreCase, boolean regex) {
+		this.strategyId = strategyId;
+		this.phrase = phrase;
+		this.ignoreCase = ignoreCase;
+		this.regex = regex;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public int getStrategyId() {
+		return this.strategyId;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public String getPhrase() {
+		return this.phrase;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public boolean isIgnoreCase() {
+		return ignoreCase;
+	}
+
+	@SuppressWarnings("unused") // used by Jelly EL
+	public boolean isRegex() {
+		return regex;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean includeCategory(@Nonnull SCMHeadCategory category) {
+		return category.isUncategorized();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected void decorateContext(SCMSourceContext<?, ?> context) {
+		StringFilter filter = createFilter();
+		if (strategyId == 1) {
+			context.withFilter(new PullRequestTargetBranchNotMatchesFilter(filter));
+		} else if (strategyId == 2) {
+			context.withFilter(new PullRequestTargetBranchMatchesFilter(filter));
+		}
+	}
+
+	/**
+	 * Create a filter to validate the data of pull request.
+	 *
+	 * @return A {@link TypeFilter} instance to validate the extracted data from
+	 *         pull request.
+	 */
+	protected StringFilter createFilter() {
+		try {
+			if (regex) {
+				int regexFlags = ignoreCase ? Pattern.CASE_INSENSITIVE : 0;
+				return new StringFilter(phrase != null ? Pattern.compile(phrase, regexFlags) : null);
+			}
+			return new StringFilter(phrase, ignoreCase);
+		} catch (Throwable t) {
+			return null;
+		}
+	}
+
+	@Extension
+	@Discovery
+	public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public String getDisplayName() {
+			return "Filter by pull requests target branch";
+		}
+
+		/**
+		 * Populates the strategy options.
+		 *
+		 * @return the strategy options.
+		 */
+		@Nonnull
+		@Restricted(NoExternalUse.class)
+		@SuppressWarnings("unused") // stapler
+		public ListBoxModel doFillStrategyIdItems() {
+			ListBoxModel result = new ListBoxModel();
+			result.add("Accept pull requests with all target branches", "0");
+			result.add("Ignore pull requests when target branch matches the phrase", "1");
+			result.add("Accept pull request only when target branch matches the phrase", "2");
+			return result;
+		}
+
+		/**
+		 * Validate the inputs
+		 *
+		 * @param phrase      The phrase or the regular expression as pattern to
+		 *                    matching
+		 * @param ignoreCase  Ignore case sensitivity
+		 * @param regex       Treat the phrase as regular expression
+		 * @param testMatcher The subject to validate by the pattern or the phrase
+		 * @return validation status
+		 */
+		@Nonnull
+		@Restricted(NoExternalUse.class)
+		public FormValidation doTestPhrase(@QueryParameter("phrase") final String phrase,
+				@QueryParameter("ignoreCase") final boolean ignoreCase, @QueryParameter("regex") final boolean regex,
+				@QueryParameter("testMatcher") final String testMatcher) {
+			try {
+				StringFilter filter;
+				if (regex) {
+					filter = new StringFilter(Pattern.compile(phrase, ignoreCase ? Pattern.CASE_INSENSITIVE : 0));
+				} else {
+					filter = new StringFilter(phrase, ignoreCase);
+				}
+				if (filter.accepted(testMatcher)) {
+					return FormValidation.ok("The phrase is valid and matches!");
+				} else {
+					return FormValidation.warning("The phrase is valid but not matches!");
+				}
+			} catch (Throwable t) {
+				return FormValidation.error("Invalid phrase: " + t.getMessage());
+			}
+		}
+	}
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/config.jelly
@@ -1,0 +1,30 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Strategy}" field="strategyId">
+      <f:select default="1" />
+    </f:entry>
+
+    <f:entry title="Phrase(s)" field="phrase">
+        <f:textbox default="(master|main)" />
+    </f:entry>
+
+    <f:entry title="Ignore case" field="ignoreCase">
+         <f:checkbox default="false" />
+    </f:entry>
+
+    <f:entry title="Regular expression" field="regex">
+         <f:checkbox default="true" />
+    </f:entry>
+
+    <f:entry>
+        <hr />
+    </f:entry>
+
+    <f:entry title="Test sequence" field="testMatcher">
+         <f:textbox />
+    </f:entry>
+
+    <f:validateButton title="${%Validate phrase}" progress="${%Validating...}"
+                      method="testPhrase" with="phrase,ignoreCase,regex,testMatcher" />
+</j:jelly>
+ 

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-ignoreCase.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-ignoreCase.html
@@ -1,0 +1,3 @@
+<div>
+    Case sensitivity defines whether uppercase and lowercase letters are treated as distinct (unchecked) or equivalent (checked).
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-phrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-phrase.html
@@ -1,0 +1,3 @@
+<div>
+    Phrases to match a title of the pull request. Use ',' to split multiple phrases - only for no regular expression.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-regex.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-regex.html
@@ -1,0 +1,3 @@
+<div>
+    Treat a phrase as a regular expression. Note, the comma character is part of the expression!
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-testMatcher.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help-testMatcher.html
@@ -1,0 +1,3 @@
+<div>
+    Source branch name sample of a pull-request to verify if will match against this pattern or contains one of the phrases.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestSourceBranchFilterTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Filter Bitbucket Pull Requests by source branch.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/config.jelly
@@ -1,0 +1,30 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Strategy}" field="strategyId">
+      <f:select default="1" />
+    </f:entry>
+
+    <f:entry title="Phrase(s)" field="phrase">
+        <f:textbox default="(master|main)" />
+    </f:entry>
+
+    <f:entry title="Ignore case" field="ignoreCase">
+         <f:checkbox default="false" />
+    </f:entry>
+
+    <f:entry title="Regular expression" field="regex">
+         <f:checkbox default="true" />
+    </f:entry>
+
+    <f:entry>
+        <hr />
+    </f:entry>
+
+    <f:entry title="Test sequence" field="testMatcher">
+         <f:textbox />
+    </f:entry>
+
+    <f:validateButton title="${%Validate phrase}" progress="${%Validating...}"
+                      method="testPhrase" with="phrase,ignoreCase,regex,testMatcher" />
+</j:jelly>
+ 

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-ignoreCase.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-ignoreCase.html
@@ -1,0 +1,3 @@
+<div>
+    Case sensitivity defines whether uppercase and lowercase letters are treated as distinct (unchecked) or equivalent (checked).
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-phrase.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-phrase.html
@@ -1,0 +1,3 @@
+<div>
+    Phrases to match a title of the pull request. Use ',' to split multiple phrases - only for no regular expression.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-regex.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-regex.html
@@ -1,0 +1,3 @@
+<div>
+    Treat a phrase as a regular expression. Note, the comma character is part of the expression!
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-testMatcher.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help-testMatcher.html
@@ -1,0 +1,3 @@
+<div>
+    Target branch name sample of a pull-request to verify if will match against this pattern or contains one of the phrases.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/bitbucket/pullrequests/filter/traits/PullRequestTargetBranchFilterTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Filter Bitbucket Pull Requests by target branch.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchMatchesFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchMatchesFilterTest.java
@@ -1,0 +1,237 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import hudson.model.TaskListener;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PullRequestSourceBranchMatchesFilter.class, BitbucketSCMSourceRequest.class})
+public class PullRequestSourceBranchMatchesFilterTest {
+
+    @Mock
+    BitbucketSCMSourceRequest scmSourceRequest;
+
+    @Mock
+    BitbucketPullRequest pullRequest;
+
+    @Mock
+    BitbucketPullRequestSource pullRequestSource;
+
+    @Mock
+    BitbucketBranch branch;
+
+    @Mock
+    PullRequestSCMHead pullRequestSCMHead;
+
+    @Mock
+    TaskListener taskListener;
+
+    @Mock
+    PrintStream logger;
+
+    @Before
+    public void setUp() throws Throwable {
+        when(taskListener.getLogger()).thenReturn(logger);
+        when(pullRequest.getId()).thenReturn("1");
+        when(pullRequest.getSource()).thenReturn(pullRequestSource);
+        when(pullRequestSource.getBranch()).thenReturn(branch);
+        when(pullRequestSCMHead.getId()).thenReturn("1");
+        when(scmSourceRequest.listener()).thenReturn(taskListener);
+        when(scmSourceRequest.getPullRequests()).thenReturn(Arrays.asList(pullRequest));
+        when(scmSourceRequest.getPullRequestById(1)).thenReturn(pullRequest);
+    }
+    
+    private void setupBranchNameMock(String branchName) {
+        when(branch.getName()).thenReturn(branchName);
+        when(pullRequestSCMHead.getBranchName()).thenReturn(branchName);
+    }
+
+    @Test
+    public void testCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupBranchNameMock("Test-branch-name");
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("Test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNegativeCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testCaseInsensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", true)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testPhraseAsPartOfWord() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("Test-title");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("t")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNotExistsPhrase() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("not-the-same")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testEmptyPhrase() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNullPhrase() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((String) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^Te??.*"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNotExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^te??$"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testEmptyPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile(""))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNullPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((Pattern) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    private SCMHeadFilter givenSCMHeadFilter(StringFilter filter) {
+        return new PullRequestSourceBranchMatchesFilter(filter);
+    }
+
+    private StringFilter givenFilter(Pattern pattern) {
+        return new StringFilter(pattern);
+    }
+
+    private StringFilter givenFilter(String phrase, boolean ignoreCase) {
+        return new StringFilter(phrase, ignoreCase);
+    }
+
+    private StringFilter givenFilter(String phrase) {
+        return givenFilter(phrase, true);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchNotMatchesFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestSourceBranchNotMatchesFilterTest.java
@@ -1,0 +1,237 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import hudson.model.TaskListener;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PullRequestSourceBranchNotMatchesFilter.class, BitbucketSCMSourceRequest.class})
+public class PullRequestSourceBranchNotMatchesFilterTest {
+
+    @Mock
+    BitbucketSCMSourceRequest scmSourceRequest;
+
+    @Mock
+    BitbucketPullRequest pullRequest;
+
+    @Mock
+    BitbucketPullRequestSource pullRequestSource;
+
+    @Mock
+    BitbucketBranch branch;
+
+    @Mock
+    PullRequestSCMHead pullRequestSCMHead;
+
+    @Mock
+    TaskListener taskListener;
+
+    @Mock
+    PrintStream logger;
+
+    @Before
+    public void setUp() throws Throwable {
+        when(taskListener.getLogger()).thenReturn(logger);
+        when(pullRequest.getId()).thenReturn("1");
+        when(pullRequest.getSource()).thenReturn(pullRequestSource);
+        when(pullRequestSource.getBranch()).thenReturn(branch);
+        when(pullRequestSCMHead.getId()).thenReturn("1");
+        when(scmSourceRequest.listener()).thenReturn(taskListener);
+        when(scmSourceRequest.getPullRequests()).thenReturn(Arrays.asList(pullRequest));
+        when(scmSourceRequest.getPullRequestById(1)).thenReturn(pullRequest);
+    }
+    
+    private void setupBranchNameMock(String branchName) {
+        when(branch.getName()).thenReturn(branchName);
+        when(pullRequestSCMHead.getBranchName()).thenReturn(branchName);
+    }
+
+    @Test
+    public void testCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupBranchNameMock("Test-branch-name");
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("Test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNegativeCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testCaseInsensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", true)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testPhraseAsPartOfWord() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("Test-title");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("t")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNotExistsPhrase() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("not-the-same")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testEmptyPhrase() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNullPhrase() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((String) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^Te??.*"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNotExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^te??$"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testEmptyPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile(""))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNullPattern() throws IOException, InterruptedException {
+        // given
+        setupBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((Pattern) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    private SCMHeadFilter givenSCMHeadFilter(StringFilter filter) {
+        return new PullRequestSourceBranchNotMatchesFilter(filter);
+    }
+
+    private StringFilter givenFilter(Pattern pattern) {
+        return new StringFilter(pattern);
+    }
+
+    private StringFilter givenFilter(String phrase, boolean ignoreCase) {
+        return new StringFilter(phrase, ignoreCase);
+    }
+
+    private StringFilter givenFilter(String phrase) {
+        return givenFilter(phrase, true);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchMatchesFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchMatchesFilterTest.java
@@ -1,0 +1,249 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestDestination;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+
+import hudson.model.TaskListener;
+import jenkins.scm.api.trait.SCMHeadFilter;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PullRequestSourceBranchMatchesFilter.class, BitbucketSCMSourceRequest.class})
+public class PullRequestTargetBranchMatchesFilterTest {
+
+    @Mock
+    BitbucketSCMSourceRequest scmSourceRequest;
+
+    @Mock
+    BitbucketPullRequest pullRequest;
+
+    @Mock
+    BitbucketPullRequestDestination pullRequestDestination;
+
+    @Mock
+    BitbucketPullRequestSource pullRequestSource;
+
+    @Mock
+    BitbucketBranch sourceBranch;
+
+    @Mock
+    BitbucketBranch targetBranch;
+
+    @Mock
+    PullRequestSCMHead pullRequestSCMHead;
+
+    @Mock
+    TaskListener taskListener;
+
+    @Mock
+    PrintStream logger;
+
+    @Before
+    public void setUp() throws Throwable {
+        when(taskListener.getLogger()).thenReturn(logger);
+        when(pullRequest.getId()).thenReturn("1");
+        when(pullRequest.getDestination()).thenReturn(pullRequestDestination);
+        when(pullRequest.getSource()).thenReturn(pullRequestSource);
+        when(pullRequestDestination.getBranch()).thenReturn(targetBranch);
+        when(pullRequestSource.getBranch()).thenReturn(sourceBranch);
+        when(sourceBranch.getName()).thenReturn("dummy");
+        when(pullRequestSCMHead.getBranchName()).thenReturn("dummy");
+        when(pullRequestSCMHead.getId()).thenReturn("1");
+        when(scmSourceRequest.listener()).thenReturn(taskListener);
+        when(scmSourceRequest.getPullRequests()).thenReturn(Arrays.asList(pullRequest));
+        when(scmSourceRequest.getPullRequestById(1)).thenReturn(pullRequest);
+    }
+    
+    private void setupTargetBranchNameMock(String branchName) {
+        when(targetBranch.getName()).thenReturn(branchName);
+    }
+
+    @Test
+    public void testCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupTargetBranchNameMock("Test-branch-name");
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("Test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNegativeCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testCaseInsensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", true)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testPhraseAsPartOfWord() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("Test-title");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("t")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNotExistsPhrase() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("not-the-same")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testEmptyPhrase() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNullPhrase() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((String) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^Te??.*"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNotExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^te??$"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testEmptyPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile(""))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNullPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((Pattern) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    private SCMHeadFilter givenSCMHeadFilter(StringFilter filter) {
+        return new PullRequestTargetBranchMatchesFilter(filter);
+    }
+
+    private StringFilter givenFilter(Pattern pattern) {
+        return new StringFilter(pattern);
+    }
+
+    private StringFilter givenFilter(String phrase, boolean ignoreCase) {
+        return new StringFilter(phrase, ignoreCase);
+    }
+
+    private StringFilter givenFilter(String phrase) {
+        return givenFilter(phrase, true);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchNotMatchesFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/bitbucket/pullrequests/filter/filters/branch/PullRequestTargetBranchNotMatchesFilterTest.java
@@ -1,0 +1,250 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023, Gabriel Einsdorf.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.bitbucket.pullrequests.filter.filters.branch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.jenkinsci.plugins.bitbucket.pullrequests.filter.utils.filters.StringFilter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestDestination;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+
+import hudson.model.TaskListener;
+import jenkins.scm.api.trait.SCMHeadFilter;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PullRequestSourceBranchNotMatchesFilter.class, BitbucketSCMSourceRequest.class})
+public class PullRequestTargetBranchNotMatchesFilterTest {
+
+
+    @Mock
+    BitbucketSCMSourceRequest scmSourceRequest;
+
+    @Mock
+    BitbucketPullRequest pullRequest;
+
+    @Mock
+    BitbucketPullRequestDestination pullRequestDestination;
+
+    @Mock
+    BitbucketPullRequestSource pullRequestSource;
+
+    @Mock
+    BitbucketBranch sourceBranch;
+
+    @Mock
+    BitbucketBranch targetBranch;
+
+    @Mock
+    PullRequestSCMHead pullRequestSCMHead;
+
+    @Mock
+    TaskListener taskListener;
+
+    @Mock
+    PrintStream logger;
+
+    @Before
+    public void setUp() throws Throwable {
+        when(taskListener.getLogger()).thenReturn(logger);
+        when(pullRequest.getId()).thenReturn("1");
+        when(pullRequest.getDestination()).thenReturn(pullRequestDestination);
+        when(pullRequest.getSource()).thenReturn(pullRequestSource);
+        when(pullRequestDestination.getBranch()).thenReturn(targetBranch);
+        when(pullRequestSource.getBranch()).thenReturn(sourceBranch);
+        when(sourceBranch.getName()).thenReturn("dummy");
+        when(pullRequestSCMHead.getBranchName()).thenReturn("dummy");
+        when(pullRequestSCMHead.getId()).thenReturn("1");
+        when(scmSourceRequest.listener()).thenReturn(taskListener);
+        when(scmSourceRequest.getPullRequests()).thenReturn(Arrays.asList(pullRequest));
+        when(scmSourceRequest.getPullRequestById(1)).thenReturn(pullRequest);
+    }
+    
+    private void setupTargetBranchNameMock(String branchName) {
+        when(targetBranch.getName()).thenReturn(branchName);
+    }
+
+    @Test
+    public void testCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupTargetBranchNameMock("Test-branch-name");
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("Test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNegativeCaseSensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", false)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testCaseInsensitivePhrase() throws IOException, InterruptedException {
+        // given
+    	setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("test", true)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testPhraseAsPartOfWord() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("Test-title");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("t")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNotExistsPhrase() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("not-the-same")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testEmptyPhrase() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter("")).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNullPhrase() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((String) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^Te??.*"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isTrue();
+    }
+
+    @Test
+    public void testNotExistsPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("Test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile("^te??$"))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testEmptyPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter(Pattern.compile(""))).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    @Test
+    public void testNullPattern() throws IOException, InterruptedException {
+        // given
+        setupTargetBranchNameMock("test-branch-name");
+
+        // when
+        boolean isExcluded = givenSCMHeadFilter(givenFilter((Pattern) null)).isExcluded(scmSourceRequest, pullRequestSCMHead);
+
+        // then
+        assertThat(isExcluded).isFalse();
+    }
+
+    private SCMHeadFilter givenSCMHeadFilter(StringFilter filter) {
+        return new PullRequestTargetBranchNotMatchesFilter(filter);
+    }
+
+    private StringFilter givenFilter(Pattern pattern) {
+        return new StringFilter(pattern);
+    }
+
+    private StringFilter givenFilter(String phrase, boolean ignoreCase) {
+        return new StringFilter(phrase, ignoreCase);
+    }
+
+    private StringFilter givenFilter(String phrase) {
+        return givenFilter(phrase, true);
+    }
+}


### PR DESCRIPTION
I added additional filter traits to filter pull requests by origin and destination branch.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

